### PR TITLE
Fix Python 3.10 compatibility for Streamlit Cloud

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.13.3
-aiosignal==1.3.1
+aiosignal==1.4.0
 altair==6.0.0
 async-timeout==5.0.1
 attrs==24.3.0
@@ -31,10 +31,10 @@ markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
 multidict==6.1.0
-numpy==2.4.1
+numpy==2.2.6
 openai==2.15.0
 packaging==26.0
-pandas==2.3.3
+pandas==2.2.3
 Pillow==12.1.0
 proto-plus==1.26.1
 protobuf==6.33.4
@@ -53,8 +53,8 @@ requests==2.32.5
 rich==14.3.1
 rpds-py==0.22.3
 rsa==4.9
-scikit-learn==1.8.0
-scipy==1.17.0
+scikit-learn==1.6.1
+scipy==1.15.2
 six==1.17.0
 smmap==5.0.2
 streamlit==1.53.1


### PR DESCRIPTION
- aiosignal: 1.3.1 → 1.4.0 (required by aiohttp 3.13.3)
- numpy: 2.4.1 → 2.2.6 (2.3+ requires Python 3.11)
- pandas: 2.3.3 → 2.2.3 (2.3+ requires Python 3.11)
- scipy: 1.17.0 → 1.15.2 (1.16+ requires Python 3.11)
- scikit-learn: 1.8.0 → 1.6.1 (1.7+ requires Python 3.10 min, 1.8 requires 3.11)