### PR TITLE
Fix protobuf version conflict

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -37,7 +37,7 @@ packaging==26.0
 pandas==2.3.3
 Pillow==12.1.0
 proto-plus==1.26.1
-protobuf==6.33.4
+protobuf==5.29.3
 pyarrow==23.0.0
 pyasn1==0.6.1
 pyasn1-modules==0.4.1


### PR DESCRIPTION
- protobuf: 6.33.4 → 5.29.3 (googleapis-common-protos requires protobuf<6.0.0)