### PR TITLE
Fix grpcio version conflict with protobuf

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -19,8 +19,8 @@ google-auth==2.47.0
 google-cloud-core==2.5.0
 google-cloud-firestore==2.23.0
 googleapis-common-protos==1.66.0
-grpcio==1.76.0
-grpcio-status==1.76.0
+grpcio==1.62.3
+grpcio-status==1.62.3
 idna==3.10
 importlib-metadata==8.5.0
 Jinja2==3.1.6


### PR DESCRIPTION
- grpcio: 1.76.0 → 1.62.3 (1.76 requires protobuf>=6.31.1)
- grpcio-status: 1.76.0 → 1.62.3 (must match grpcio version)
- Keep protobuf at 5.29.3 (required by googleapis-common-protos<6.0.0)