### PR TITLE
Fix rpds-py version for jsonschema compatibility

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -51,7 +51,7 @@ pytz==2024.2
 referencing==0.36.2
 requests==2.32.5
 rich==14.3.1
-rpds-py==0.22.3
+rpds-py==0.25.1
 rsa==4.9
 scikit-learn==1.8.0
 scipy==1.17.0


### PR DESCRIPTION
- rpds-py: 0.22.3 → 0.25.1 (jsonschema 4.26.0 requires rpds-py>=0.25.0)