### PR TITLE
Replace deprecated Streamlit experimental APIs

### DIFF
--- a/app/pages/2_assistant.py
+++ b/app/pages/2_assistant.py
@@ -116,9 +116,8 @@ def handler_session_rating(liked):
 
 def handler_bot_cancellation():
     del st.session_state.bot_info
-    url_params = st.experimental_get_query_params()
-    if bool(url_params) == True and 'assistant_id' in url_params:
-        st.experimental_set_query_params(assistant_id="")
+    if 'assistant_id' in st.query_params:
+        del st.query_params['assistant_id']
 
 
 def handler_load_past_session(session_id,bot_id):
@@ -328,18 +327,17 @@ if 'user' not in st.session_state or st.session_state.user['id'] is None:
     render_user_login_required()
 else:
     if 'bot_info' not in st.session_state:
-        # first check url_params for asssitant_id
-        url_params = st.experimental_get_query_params()
-        if bool(url_params) == True and 'assistant_id' in url_params:
-            if url_params['assistant_id'][0] != "":
-                bot_found = handler_bot_search(user_search_str=url_params['assistant_id'][0])
-                if bot_found == False:
-                    st.error("Assistant in URL cannot be found")
-                    st.experimental_set_query_params(assistant_id="")
-                    render_bot_search()
-                else:
-                    # bot found. Get UI to re-render
-                    st.experimental_rerun()
+        # first check url_params for assistant_id
+        assistant_id = st.query_params.get('assistant_id', '')
+        if assistant_id:
+            bot_found = handler_bot_search(user_search_str=assistant_id)
+            if bot_found == False:
+                st.error("Assistant in URL cannot be found")
+                del st.query_params['assistant_id']
+                render_bot_search()
+            else:
+                # bot found. Get UI to re-render
+                st.rerun()
         else:
             render_bot_search()
     else:

--- a/app/pages/3_lab.py
+++ b/app/pages/3_lab.py
@@ -356,7 +356,7 @@ def handle_lab_restart():
         'lab_model_index', 'lab_model_personality_index', 'lab_model_max_tokens_input'
     ])
     st.session_state.lab_active_step = 1
-    st.experimental_rerun()
+    st.rerun()
 
 
 def _on_lab_error(e):


### PR DESCRIPTION
- Replace st.experimental_get_query_params with st.query_params
- Replace st.experimental_set_query_params with del st.query_params[key]
- Replace st.experimental_rerun with st.rerun

These APIs were deprecated and scheduled for removal after 2024-04-11.